### PR TITLE
Compile with 64 bit flags for Mac

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -44,6 +44,10 @@ ifeq ($(UNAME), Darwin)
 	# Mac OS X (32-bit build)
 	LDFLAGS += -m32
 	CPPFLAGS += -m32 -DHAVE_POLL_H
+	
+	# Mac OS X (64-bit build)
+	# LDFLAGS += -m64
+	# CPPFLAGS += -m64 -DHAVE_POLL_H
 
 	ifeq ("$(shell which llvm-gcc)", "")
 		# We want to support all the way back to OS 10.6 (Snow Leopard), which used gcc


### PR DESCRIPTION
Compile with 64 bit flags for Mac from the original repo. 64 bit is commented out but it's there if needed.

Based on this thread: https://github.com/scanlime/fadecandy/pull/134